### PR TITLE
Refactor of CN and IC module

### DIFF
--- a/auditory_nerve2018.py
+++ b/auditory_nerve2018.py
@@ -94,6 +94,5 @@ def auditory_nerve_fiber(Vm,fs,spont):
     return solution
 
 
-
-
-
+def sumAN(anfH, anfM, anfL, numH, numM, numL):
+    return numL*anfL+numM*anfM+numH*anfH

--- a/run_model2018.py
+++ b/run_model2018.py
@@ -136,8 +136,26 @@ def solve_one_cochlea(model): #definition here, to have all the parameter implic
         sio.savemat(fname,mdict)
 
     if 'b' in storeflag or 'w' in storeflag:
-        cn,anSummed=nuclei.cochlearNuclei(anfH,anfM,anfL,numH,numM,numL,Fs_res)
-        ic=nuclei.inferiorColliculus(cn,Fs_res)
+        # Going forward I highly recommend that the last two dimensions of the
+        # array be CF x time (i.e., time should be the last dimension). This
+        # will make the code play much more nicely with other Python modules.
+        # Right now we need to transpose the arrays to ensure uniformity with
+        # what the Matlab code expects.
+        anSummed = anf.sumAN(anfH, anfM, anfL, numH, numM, numL)
+
+        # Need to convert from time x CF to CF x time (because the cochlear,
+        # IHC and auditory nerve code has not yet been updated).
+        anSummed = anSummed.T
+        cn = nuclei.cochlearNuclei(anSummed, Fs_res)
+        ic = nuclei.inferiorColliculus(cn, Fs_res)
+
+        # Now, convert from CF x time to time x CF since the Matlab code
+        # expects it in that format. In general, Python and Matlab tend to take
+        # different approaches to the ordering of dimensions due to the Fortran
+        # (Matlab) vs. C (numpy) optimizations.
+        anSUmmed = anSummed.T
+        cn = cn.T
+        ic = ic.T
 
         if 'b' in storeflag:
             fname = output_folder+"cn"+str(ii+1)+".mat"


### PR DESCRIPTION
This refactor will make it easier for me to integrate the EFR
simulations into the Bayesian regression models I'm running. Main
changes include:

* Breaking out common operations (e.g., calculating the bilinear filter
  and inserting delays) into their own functions.
* Updating the code to better handle N-dimensional arrays. Original
  version of the code assumes that the AN and CN data will only be 2
  dimensional with dimensions (time x CF). This was causing problems
  because my simulation is using four dimensions (stimulus x subject x
  CF x time).
* Time should generally be the *last* dimension due to Python coding
  conventions (in Matlab, time is usually the *first* dimension, but
  this has to do with Matlab being Fortran based vs. Python/Numpy being
  C/C++ based).
* The run_model2018.py has been updated to reflect the dimension
  reordering of the ic_cn2018 module. Eventually I will submit changes
  reflecting the CF x time ordering for additional modules.

These changes have been verified against the original code and shown to
yield identical results for CN and IC outputs.